### PR TITLE
Fix parsing tests

### DIFF
--- a/src/parser/session.rs
+++ b/src/parser/session.rs
@@ -47,8 +47,13 @@ impl SessionParser {
                 }
             };
             
-            // Check the type field
-            match json_value.get("type").and_then(|t| t.as_str()) {
+            // Check the record type field, supporting both `type` and `message_type`
+            let record_type = json_value
+                .get("type")
+                .or_else(|| json_value.get("message_type"))
+                .and_then(|t| t.as_str());
+
+            match record_type {
                 Some("summary") => {
                     match serde_json::from_value::<SummaryRecord>(json_value) {
                         Ok(summary) => summaries.push(summary),
@@ -84,7 +89,7 @@ impl SessionParser {
                 None => {
                     return Err(ClaudeError::ParseError(ParseError::InvalidJsonl {
                         line: line_num + 1,
-                        message: "Missing 'type' field".to_string(),
+                        message: "Missing 'type' or 'message_type' field".to_string(),
                     }));
                 }
             }

--- a/src/types/enums.rs
+++ b/src/types/enums.rs
@@ -4,9 +4,9 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum UserType {
-    #[serde(rename = "external")]
+    #[serde(rename = "external", alias = "human")]
     External,
-    #[serde(rename = "internal")]
+    #[serde(rename = "internal", alias = "system")]
     Internal,
 }
 

--- a/src/types/message.rs
+++ b/src/types/message.rs
@@ -9,30 +9,30 @@ use super::enums::{UserType, MessageType, Role, StopReason};
 /// Represents a single message record from Claude Code JSONL
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MessageRecord {
-    #[serde(rename = "parentUuid")]
+    #[serde(rename = "parentUuid", alias = "parent_uuid")]
     pub parent_uuid: Option<Uuid>,
-    #[serde(rename = "isSidechain")]
+    #[serde(rename = "isSidechain", alias = "is_sidechain")]
     pub is_sidechain: bool,
-    #[serde(rename = "userType")]
+    #[serde(rename = "userType", alias = "user_type")]
     pub user_type: UserType,
     pub cwd: PathBuf,
-    #[serde(rename = "sessionId")]
+    #[serde(rename = "sessionId", alias = "session_id")]
     pub session_id: String,
     pub version: String,
-    #[serde(rename = "type")]
+    #[serde(rename = "type", alias = "message_type")]
     pub message_type: MessageType,
     pub message: Message,
-    #[serde(rename = "costUSD")]
+    #[serde(rename = "costUSD", alias = "cost_usd")]
     pub cost_usd: Option<f64>,
-    #[serde(rename = "durationMs")]
+    #[serde(rename = "durationMs", alias = "duration_ms")]
     pub duration_ms: Option<u64>,
-    #[serde(rename = "requestId")]
+    #[serde(rename = "requestId", alias = "request_id")]
     pub request_id: Option<String>,
     pub uuid: Uuid,
     pub timestamp: DateTime<Utc>,
-    #[serde(rename = "toolUseResult")]
+    #[serde(rename = "toolUseResult", alias = "tool_use_result")]
     pub tool_use_result: Option<serde_json::Value>,
-    #[serde(rename = "isMeta")]
+    #[serde(rename = "isMeta", alias = "is_meta")]
     pub is_meta: Option<bool>,
 }
 


### PR DESCRIPTION
## Summary
- handle `message_type` and other snake case fields when parsing
- allow `human`/`system` as aliases for `UserType`

## Testing
- `cargo test --no-fail-fast`
- `uv run -- python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e62d16104832e96ae363a3bceda9a