### PR TITLE
Replace eprintln with tracing

### DIFF
--- a/src/execution/observer.rs
+++ b/src/execution/observer.rs
@@ -133,8 +133,8 @@ impl EnvironmentObserver {
             
         let project_dir = claude_projects.join(&project_name);
         
-        eprintln!("Looking for Claude project: {:?}", project_dir);
-        eprintln!("Project exists: {}", project_dir.exists());
+        tracing::debug!("Looking for Claude project: {:?}", project_dir);
+        tracing::debug!("Project exists: {}", project_dir.exists());
         
         if !project_dir.exists() {
             return Err(ObserverError::ProjectNotFound(format!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,8 +5,8 @@ fn main() -> Result<(), ClaudeError> {
     let args: Vec<String> = env::args().collect();
 
     if args.len() < 2 {
-        eprintln!("Usage: {} <session.jsonl>", args[0]);
-        eprintln!(
+        tracing::error!("Usage: {} <session.jsonl>", args[0]);
+        tracing::error!(
             "\nExample: {} /path/to/session_20240101_120000.jsonl",
             args[0]
         );

--- a/src/parser/session.rs
+++ b/src/parser/session.rs
@@ -79,7 +79,7 @@ impl SessionParser {
                 }
                 Some(other) => {
                     // Unknown record type - skip it
-                    eprintln!("Warning: Unknown record type '{}' at line {}, skipping", other, line_num + 1);
+                    tracing::warn!("Unknown record type '{}' at line {}, skipping", other, line_num + 1);
                 }
                 None => {
                     return Err(ClaudeError::ParseError(ParseError::InvalidJsonl {

--- a/src/python/functions.rs
+++ b/src/python/functions.rs
@@ -240,7 +240,11 @@ pub fn load_project(project_identifier: &str, base_path: Option<&str>) -> PyResu
             }
             Err(e) => {
                 // Log warning but continue loading other sessions
-                eprintln!("Warning: Failed to parse session {}: {}", session_path.display(), e);
+                tracing::warn!(
+                    "Failed to parse session {}: {}",
+                    session_path.display(),
+                    e
+                );
             }
         }
     }

--- a/src/types/project.rs
+++ b/src/types/project.rs
@@ -142,7 +142,11 @@ impl Project {
                 }
                 Err(e) => {
                     // Log other errors but continue processing
-                    eprintln!("Warning: Failed to parse session file {:?}: {}", file_path, e);
+                    tracing::warn!(
+                        "Failed to parse session file {:?}: {}",
+                        file_path,
+                        e
+                    );
                     continue;
                 }
             }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -49,7 +49,7 @@ fn test_parse_real_sessions_impl() {
     let projects_dir = match get_claude_projects_dir() {
         Some(dir) => dir,
         None => {
-            eprintln!("Claude projects directory not found, skipping integration tests");
+            tracing::warn!("Claude projects directory not found, skipping integration tests");
             return;
         }
     };
@@ -147,7 +147,7 @@ fn test_large_session_performance() {
     let projects_dir = match get_claude_projects_dir() {
         Some(dir) => dir,
         None => {
-            eprintln!("Claude projects directory not found, skipping test");
+            tracing::warn!("Claude projects directory not found, skipping test");
             return;
         }
     };
@@ -209,7 +209,7 @@ fn test_tool_extraction_real_data() {
     let projects_dir = match get_claude_projects_dir() {
         Some(dir) => dir,
         None => {
-            eprintln!("Claude projects directory not found, skipping test");
+            tracing::warn!("Claude projects directory not found, skipping test");
             return;
         }
     };
@@ -262,7 +262,7 @@ fn test_session_info_quick_scan() {
     let projects_dir = match get_claude_projects_dir() {
         Some(dir) => dir,
         None => {
-            eprintln!("Claude projects directory not found, skipping test");
+            tracing::warn!("Claude projects directory not found, skipping test");
             return;
         }
     };


### PR DESCRIPTION
## Summary
- replace all `eprintln!` calls with the appropriate `tracing` macros

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_683e9ae14f74832eaf38570df5d9c1ae