### PR TITLE
Expose snapshot_files for environment capture

### DIFF
--- a/src/execution/conversation.rs
+++ b/src/execution/conversation.rs
@@ -64,7 +64,7 @@ impl Conversation {
         let before = if self.session_ids.is_empty() {
             // First message - no session to snapshot
             EnvironmentSnapshot {
-                files: self.workspace.snapshot()?.files,
+                files: self.workspace.snapshot_files()?,
                 session_file: PathBuf::new(),
                 timestamp: Utc::now(),
                 session: None,

--- a/src/execution/observer.rs
+++ b/src/execution/observer.rs
@@ -93,7 +93,7 @@ impl EnvironmentObserver {
         })
     }
     
-    fn snapshot_files(&self) -> Result<HashMap<PathBuf, String>, ObserverError> {
+    pub fn snapshot_files(&self) -> Result<HashMap<PathBuf, String>, ObserverError> {
         let mut files = HashMap::new();
         
         for pattern in &self.file_patterns {

--- a/src/execution/workspace.rs
+++ b/src/execution/workspace.rs
@@ -5,6 +5,7 @@
 //! is now handled by Conversation.
 
 use std::path::PathBuf;
+use std::collections::HashMap;
 use crate::execution::{
     ClaudeExecutor, ExecutorError,
     EnvironmentObserver, EnvironmentSnapshot, ObserverError,
@@ -40,6 +41,12 @@ impl Workspace {
     /// Take a snapshot of the current workspace state
     pub fn snapshot(&self) -> Result<EnvironmentSnapshot, WorkspaceError> {
         self.observer.snapshot()
+            .map_err(WorkspaceError::ObserverError)
+    }
+
+    /// Capture only the workspace files without session data
+    pub fn snapshot_files(&self) -> Result<HashMap<PathBuf, String>, WorkspaceError> {
+        self.observer.snapshot_files()
             .map_err(WorkspaceError::ObserverError)
     }
     


### PR DESCRIPTION
## Summary
- expose `snapshot_files` on `EnvironmentObserver`
- surface `snapshot_files` through `Workspace`
- use `snapshot_files` when `Conversation` has no session

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_683f14d569dc832ea932d90542fac6ec