### PR TITLE
Fix workspace mutability for Python API

### DIFF
--- a/tests/t1_continue_test.rs
+++ b/tests/t1_continue_test.rs
@@ -3,7 +3,7 @@
 
 mod common;
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use claude_sdk::execution::{Workspace, Conversation};
 use common::TestEnvironment;
 
@@ -13,7 +13,7 @@ fn test_session_continuation() {
     println!("\n=== Session Continuation Test ===\n");
     
     let env = TestEnvironment::setup();
-    let workspace = Arc::new(Workspace::new(env.workspace.clone()).unwrap());
+    let workspace = Arc::new(Mutex::new(Workspace::new(env.workspace.clone()).unwrap()));
     let mut conversation = Conversation::new(workspace);
     
     // First execution - create a file

--- a/tests/t1_conversation_test.rs
+++ b/tests/t1_conversation_test.rs
@@ -3,7 +3,7 @@
 
 mod common;
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use claude_sdk::execution::{Workspace, Conversation};
 use common::TestEnvironment;
 
@@ -13,7 +13,7 @@ fn test_conversation_owns_transitions() {
     println!("\n=== Conversation V2 Test ===\n");
     
     let env = TestEnvironment::setup();
-    let workspace = Arc::new(Workspace::new(env.workspace.clone()).unwrap());
+    let workspace = Arc::new(Mutex::new(Workspace::new(env.workspace.clone()).unwrap()));
     
     // Create a conversation
     let mut conversation = Conversation::new(workspace.clone());
@@ -65,7 +65,7 @@ fn test_multiple_conversations_same_workspace() {
     println!("\n=== Multiple Conversations Test ===\n");
     
     let env = TestEnvironment::setup();
-    let workspace = Arc::new(Workspace::new(env.workspace.clone()).unwrap());
+    let workspace = Arc::new(Mutex::new(Workspace::new(env.workspace.clone()).unwrap()));
     
     // Create two conversations in same workspace
     let mut conv1 = Conversation::new(workspace.clone());
@@ -104,7 +104,7 @@ fn test_conversation_persistence() {
     println!("\n=== Conversation Persistence Test ===\n");
     
     let env = TestEnvironment::setup();
-    let workspace = Arc::new(Workspace::new(env.workspace.clone()).unwrap());
+    let workspace = Arc::new(Mutex::new(Workspace::new(env.workspace.clone()).unwrap()));
     
     let conv_id;
     let save_path = env.workspace.join("conversation.json");

--- a/tests/t1_tool_extraction_test.rs
+++ b/tests/t1_tool_extraction_test.rs
@@ -3,7 +3,7 @@
 
 mod common;
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use claude_sdk::execution::{Workspace, Conversation};
 use common::TestEnvironment;
 
@@ -13,7 +13,7 @@ fn test_tool_extraction() {
     println!("\n=== Tool Extraction Test ===\n");
     
     let env = TestEnvironment::setup();
-    let workspace = Arc::new(Workspace::new(env.workspace.clone()).unwrap());
+    let workspace = Arc::new(Mutex::new(Workspace::new(env.workspace.clone()).unwrap()));
     let mut conversation = Conversation::new(workspace);
     
     // Execute a prompt that will use multiple tools


### PR DESCRIPTION
## Summary
- wrap `Workspace` in `Arc<Mutex<_>>` for Python bindings
- update `Conversation` to lock workspace when executing
- expose `set_skip_permissions` in Python
- adjust tests for new shared workspace type

## Testing
- `cargo test --no-run`
- `uv run -- python -m pytest -q` *(fails: CLAUDE CLI not found / fixture missing)*

------
https://chatgpt.com/codex/tasks/task_e_683f95415fb0832e9dad8189b9b93fd2