### PR TITLE
Add sentinel values for pre-conversation snapshot

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -343,16 +343,22 @@ When not continuing a session, the "before" state should be empty:
 let before = if continue_session {
     self.observer.snapshot()?  // Get most recent session
 } else {
-    EnvironmentSnapshot {
-        files: self.observer.snapshot()?.files,
-        session_file: PathBuf::new(),
-        timestamp: chrono::Utc::now(),
-        session: None,  // No session to compare against
-    }
+        EnvironmentSnapshot {
+            files: self.observer.snapshot()?.files,
+            session_file: PathBuf::from(NO_SESSION_FILE),
+            session_id: Some(PRE_CONVERSATION_SESSION_ID.to_string()),
+            timestamp: chrono::Utc::now(),
+            session: None,  // No session to compare against
+        }
 };
 ```
 
 This ensures new messages are properly detected when comparing states.
+
+The sentinel `session_id` for this empty snapshot is stored in
+`PRE_CONVERSATION_SESSION_ID` (`"\u2205"`), and the corresponding
+`session_file` is the string `NO_SESSION_FILE` (`"<none>"`).  Downstream tools
+should treat these values as indicators that no prior session exists.
 
 ### TODO: API Improvements
 

--- a/src/execution/conversation.rs
+++ b/src/execution/conversation.rs
@@ -14,6 +14,7 @@ use super::{
     ClaudePrompt,
     EnvironmentSnapshot, Transition,
     recorder::{TransitionRecorder, RecorderError},
+    observer::{PRE_CONVERSATION_SESSION_ID, NO_SESSION_FILE},
 };
 
 /// Serializable representation of a Conversation
@@ -96,8 +97,8 @@ impl Conversation {
             // First message - no session to snapshot
             EnvironmentSnapshot {
                 files: self.workspace.snapshot_files()?,
-                session_file: PathBuf::new(),
-                session_id: None,
+                session_file: PathBuf::from(NO_SESSION_FILE),
+                session_id: Some(PRE_CONVERSATION_SESSION_ID.to_string()),
                 timestamp: Utc::now(),
                 session: None,
             }

--- a/src/execution/observer.rs
+++ b/src/execution/observer.rs
@@ -3,6 +3,11 @@ use std::collections::HashMap;
 use glob::glob;
 use serde::{Deserialize, Serialize};
 use chrono::{DateTime, Utc};
+
+/// Sentinel session ID used before any conversation has started.
+pub const PRE_CONVERSATION_SESSION_ID: &str = "\u{2205}"; // "∅"
+/// Sentinel path for the non-existent session file before first turn.
+pub const NO_SESSION_FILE: &str = "<none>";
 use crate::parser::SessionParser;
 use crate::types::ParsedSession;
 use crate::utils::path::encode_project_path;

--- a/tests/snapshot_serialization_test.rs
+++ b/tests/snapshot_serialization_test.rs
@@ -1,0 +1,22 @@
+use claude_sdk::execution::{observer::{EnvironmentSnapshot, PRE_CONVERSATION_SESSION_ID, NO_SESSION_FILE}};
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+#[test]
+fn test_first_snapshot_serialization_roundtrip() {
+    // create a snapshot representing the first turn
+    let snap = EnvironmentSnapshot {
+        files: HashMap::new(),
+        session_file: PathBuf::from(NO_SESSION_FILE),
+        session_id: Some(PRE_CONVERSATION_SESSION_ID.to_string()),
+        timestamp: chrono::Utc::now(),
+        session: None,
+    };
+
+    // serialize and deserialize
+    let json = serde_json::to_string(&snap).expect("serialize");
+    let deser: EnvironmentSnapshot = serde_json::from_str(&json).expect("deserialize");
+
+    assert_eq!(deser.session_id.unwrap(), PRE_CONVERSATION_SESSION_ID);
+    assert_eq!(deser.session_file, PathBuf::from(NO_SESSION_FILE));
+}


### PR DESCRIPTION
## Summary
- include sentinel constants for first-turn snapshot
- store explicit session ID and placeholder session path before first conversation turn
- document the sentinel approach in CLAUDE.md
- add unit test for first snapshot round-trip

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_683fd609d4c8832eb671d4d738d7dbfb