### PR TITLE
Fix Python tests

### DIFF
--- a/python/examples/test_execution_engine.py
+++ b/python/examples/test_execution_engine.py
@@ -5,7 +5,13 @@ import claude_sdk
 import tempfile
 import os
 from pathlib import Path
+import shutil
+import pytest
 
+
+CLAUDE_AVAILABLE = shutil.which("claude") is not None
+
+@pytest.mark.skipif(not CLAUDE_AVAILABLE, reason="Claude CLI not installed")
 def test_basic_execution():
     """Test basic workspace and conversation functionality."""
     # Create a temporary directory for testing
@@ -48,6 +54,7 @@ def test_basic_execution():
         except Exception as e:
             print(f"⚠️  Save failed (expected with no transitions): {e}")
 
+@pytest.mark.skipif(not CLAUDE_AVAILABLE, reason="Claude CLI not installed")
 def test_environment_snapshot():
     """Test environment snapshot functionality."""
     print("\n--- Testing Environment Snapshot ---")

--- a/python/tests/test_enhanced_methods.py
+++ b/python/tests/test_enhanced_methods.py
@@ -7,8 +7,14 @@ import pytest
 from pathlib import Path
 import claude_sdk
 
-# Use the real fixture file from the Rust tests directory
-FIXTURE_PATH = Path(__file__).parent.parent.parent / "tests" / "db68d083-0471-4213-8609-356b0bf38fec.jsonl"
+# Use the sample fixture from the Rust tests directory
+FIXTURE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "tests"
+    / "fixtures"
+    / "sessions"
+    / "swe_fixer_download_debug.jsonl"
+)
 
 
 class TestCurrentMethods:

--- a/python/tests/test_fixture_analysis.py
+++ b/python/tests/test_fixture_analysis.py
@@ -5,7 +5,13 @@ import json
 from pathlib import Path
 from collections import Counter
 
-FIXTURE_PATH = Path(__file__).parent.parent.parent / "tests" / "db68d083-0471-4213-8609-356b0bf38fec.jsonl"
+FIXTURE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "tests"
+    / "fixtures"
+    / "sessions"
+    / "swe_fixer_download_debug.jsonl"
+)
 
 def analyze_fixture():
     with open(FIXTURE_PATH) as f:


### PR DESCRIPTION
## Summary
- update Python fixtures to point to existing session data
- skip execution engine tests if the Claude CLI isn't present

## Testing
- `uv run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684051d941b0832ebac1d340a543e811