### PR TITLE
Add navigation docs

### DIFF
--- a/src/conversation/CLAUDE.md
+++ b/src/conversation/CLAUDE.md
@@ -1,0 +1,7 @@
+# Directory: src/conversation
+
+This module reconstructs threaded conversations from parsed Claude sessions. `ConversationTree` builds a hierarchy of messages using parent UUIDs, tracks orphaned or circular references, and exposes traversal helpers for analysis.
+
+Key files:
+- `tree.rs` defines `ConversationTree` and `ConversationNode`. Methods like `all_messages`, `leaf_nodes`, `path_to_message`, and `stats` help inspect the structure.
+- `mod.rs` re-exports the tree types for the rest of the crate.

--- a/src/execution/CLAUDE.md
+++ b/src/execution/CLAUDE.md
@@ -1,0 +1,10 @@
+# Directory: src/execution
+
+Core runtime for sending prompts to the Claude CLI and tracking workspace state. These modules power the high level conversation API.
+
+- `executor.rs` defines `ClaudeExecutor`, building command invocations and parsing JSON responses from the CLI. It also handles tool permission flags.
+- `observer.rs` produces `EnvironmentSnapshot`s of the workspace and locates session files under `~/.claude/projects`.
+- `recorder.rs` stores `Transition` structures to disk so executions can be replayed later.
+- `workspace.rs` wires the executor and observer together, exposing methods like `snapshot` and `set_allowed_tools`.
+- `conversation.rs` builds on these pieces to manage a multi-turn `Conversation` with its own history of transitions.
+- `mod.rs` simply re-exports the public types.

--- a/src/parser/CLAUDE.md
+++ b/src/parser/CLAUDE.md
@@ -1,0 +1,6 @@
+# Directory: src/parser
+
+Rust parser for Claude's line oriented JSONL session logs.
+
+- `session.rs` implements `SessionParser`. It validates each JSON record, builds `ParsedSession` with a conversation tree and metadata, and provides helpers like `records_iter`, `extract_tool_usage`, `discover_sessions`, and `session_info` for quick scans.
+- `mod.rs` re-exports the parser so other crates can create `SessionParser` instances.

--- a/src/python/CLAUDE.md
+++ b/src/python/CLAUDE.md
@@ -1,0 +1,11 @@
+# Directory: src/python
+
+Bindings that expose the Rust library to Python via PyO3. The `claude_sdk` Python package is built from these files.
+
+- `mod.rs` registers the module and pulls in all classes/functions.
+- `classes.rs` defines Python-visible wrappers for Rust types such as `Message`, `Session`, and `Project`.
+- `execution.rs` exposes `Workspace` and `Conversation` to Python, allowing scripts to drive the CLI programmatically.
+- `functions.rs` provides convenience helpers like `load` or `find_sessions` that return parsed data structures.
+- `models.rs` mirrors the Rust data models so they can be serialized/deserialized in Python.
+- `exceptions.rs` creates Python exception types for error handling.
+- `utils.rs` converts `serde_json::Value` into native Python objects.

--- a/src/types/CLAUDE.md
+++ b/src/types/CLAUDE.md
@@ -1,0 +1,12 @@
+# Directory: src/types
+
+Core data models used throughout the SDK and exposed to Python.
+
+- `message.rs` defines `MessageRecord` along with the nested `ContentBlock` variants.
+- `content.rs` describes each block type including text, tool calls, and tool results.
+- `session.rs` groups messages into a `ParsedSession` with a `ConversationTree` and metadata.
+- `metadata.rs` computes analytics like unique tools used and token counts for a session.
+- `tool.rs` records individual tool executions and helper methods for durations and success flags.
+- `project.rs` models a Claude project discovered on disk.
+- `enums.rs` holds enums for message roles and content kinds.
+- `mod.rs` re-exports these types for easy access.

--- a/src/utils/CLAUDE.md
+++ b/src/utils/CLAUDE.md
@@ -1,0 +1,8 @@
+# Directory: src/utils
+
+Helper functions for path handling, project discovery, and analyzing session data.
+
+- `path.rs` converts between filesystem paths and Claude's encoded project names.
+- `discovery.rs` walks directories to find Claude projects or session files.
+- `analysis.rs` provides utilities like `analyze_tool_patterns` and `calculate_session_metrics` for inspecting execution logs.
+- `mod.rs` re-exports these helper modules.

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -1,0 +1,8 @@
+# Directory: tests
+
+Collection of unit and integration tests for the crate. Many files are prefixed with `t1_` and focus on the execution engine. Most integration tests are ignored by default and require the Claude CLI.
+
+Notable tests:
+- `integration/` holds the CLI integration tests.
+- `fixtures/` provides sample session logs consumed by various tests.
+- `t1_*` files exercise conversation handling, workspace observation, and tool extraction.

--- a/tests/common/CLAUDE.md
+++ b/tests/common/CLAUDE.md
@@ -1,0 +1,3 @@
+# Directory: tests/common
+
+Utilities shared by multiple tests. `mod.rs` defines `TestEnvironment` which creates a temporary workspace under `~/.claude-sdk/test-environment`. It can discover the corresponding Claude project directory and locate session logs for assertions. The environment cleans up after each test via the `Drop` implementation.

--- a/tests/fixtures/CLAUDE.md
+++ b/tests/fixtures/CLAUDE.md
@@ -1,0 +1,6 @@
+# Directory: tests/fixtures
+
+Contains sample session files used by unit and integration tests.
+
+- `example_sample.jsonl` is a trimmed session used by parser unit tests.
+- `sessions/` holds short real-world logs that allow the integration tests to run without requiring a full Claude install.

--- a/tests/fixtures/sessions/CLAUDE.md
+++ b/tests/fixtures/sessions/CLAUDE.md
@@ -1,0 +1,5 @@
+# Directory: tests/fixtures/sessions
+
+Sanitized session logs that show real tool usage. These files are small enough for integration tests to parse quickly.
+
+- `swe_fixer_download_debug.jsonl` captures a short debugging workflow that includes a Bash tool call.

--- a/tests/integration/CLAUDE.md
+++ b/tests/integration/CLAUDE.md
@@ -1,0 +1,6 @@
+# Directory: tests/integration
+
+End-to-end tests that execute the real Claude CLI. They are marked `#[ignore]` and must be run manually (`cargo test -- --ignored`).
+
+- `executor_test.rs` exercises `ClaudeExecutor` by running prompts in a temporary workspace.
+- `mod.rs` acts as the test harness for additional integration modules.


### PR DESCRIPTION
## Summary
- add Claude.md docs for each folder under `src` and `tests`
- document structure of conversation, execution, parser, python bindings, types, utils, and test fixtures
- rename all docs to `CLAUDE.md` for consistency

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68404f79004c832eaa54305aee637c00