### PR TITLE
Improve message data access in Python API

### DIFF
--- a/python/tests/test_message_tool_fields.py
+++ b/python/tests/test_message_tool_fields.py
@@ -1,0 +1,17 @@
+import claude_sdk
+from pathlib import Path
+import pytest
+
+FIXTURES_DIR = Path(__file__).resolve().parents[2] / "tests" / "fixtures"
+
+
+@pytest.mark.parametrize("path", sorted(FIXTURES_DIR.rglob("*.jsonl")))
+def test_tool_fields_present(path: Path):
+    session = claude_sdk.load(path)
+    # ensure we have text for every message
+    assert all(m.text for m in session.messages)
+    # at least one tool use or result should be present in the fixture
+    assert any(m.tool_uses for m in session.messages) or any(
+        m.tool_results for m in session.messages
+    )
+

--- a/src/conversation/tree.rs
+++ b/src/conversation/tree.rs
@@ -5,7 +5,7 @@ use crate::types::MessageRecord;
 use crate::error::ParseError;
 
 /// Represents a conversation as a tree structure
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ConversationTree {
     /// Root messages (no parent)
     pub root_messages: Vec<ConversationNode>,
@@ -16,7 +16,7 @@ pub struct ConversationTree {
 }
 
 /// A node in the conversation tree
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ConversationNode {
     pub message: MessageRecord,
     pub children: Vec<ConversationNode>,

--- a/src/types/session.rs
+++ b/src/types/session.rs
@@ -33,7 +33,7 @@ pub struct SummaryRecord {
 }
 
 /// Parsed session data with metadata
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ParsedSession {
     pub session_id: SessionId,
     pub messages: Vec<MessageRecord>,

--- a/tests/execution_unit_test.rs
+++ b/tests/execution_unit_test.rs
@@ -121,7 +121,7 @@ fn sample_transition() -> Transition {
         session_file: PathBuf::from("before.jsonl"),
         session_id: Some("sess1".to_string()),
         timestamp: now,
-        session: Some(before_session),
+        session: Some(before_session.into()),
     };
 
     let after = EnvironmentSnapshot {
@@ -129,7 +129,7 @@ fn sample_transition() -> Transition {
         session_file: PathBuf::from("after.jsonl"),
         session_id: Some("sess1".to_string()),
         timestamp: now + chrono::Duration::milliseconds(2),
-        session: Some(after_session),
+        session: Some(after_session.into()),
     };
 
     let prompt = ClaudePrompt { text: "test".to_string(), continue_session: false, resume_session_id: None };

--- a/tests/fixtures/CLAUDE.md
+++ b/tests/fixtures/CLAUDE.md
@@ -3,4 +3,5 @@
 Contains sample session files used by unit and integration tests.
 
 - `example_sample.jsonl` is a trimmed session used by parser unit tests.
+- `transitions/` holds before/after snapshots derived from `example_sample.jsonl` using `scripts/update_transition_fixtures.sh`.
 - `sessions/` holds short real-world logs that allow the integration tests to run without requiring a full Claude install.

--- a/tests/fixtures/transitions/CLAUDE.md
+++ b/tests/fixtures/transitions/CLAUDE.md
@@ -1,0 +1,4 @@
+# Directory: tests/fixtures/transitions
+
+These JSONL files simulate environment snapshots for transition tests.
+They are generated from `../example_sample.jsonl` via `../scripts/update_transition_fixtures.sh`.

--- a/tests/scripts/update_transition_fixtures.sh
+++ b/tests/scripts/update_transition_fixtures.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+fixtures_dir=$(cd "$(dirname "$0")/../fixtures" && pwd)
+source_file="$fixtures_dir/example_sample.jsonl"
+dest_dir="$fixtures_dir/transitions"
+mkdir -p "$dest_dir"
+head -n 1 "$source_file" > "$dest_dir/before_example.jsonl"
+head -n 2 "$source_file" > "$dest_dir/after_example.jsonl"

--- a/tests/t1_transition_unit_test.rs
+++ b/tests/t1_transition_unit_test.rs
@@ -5,24 +5,13 @@ use claude_sdk::execution::recorder::Transition;
 use uuid::Uuid;
 use std::collections::HashMap;
 use chrono::Utc;
-use tempfile::NamedTempFile;
-use std::io::Write;
+use std::path::Path;
 
 #[test]
 fn test_transition_tool_extraction() {
-    // Load fixture lines
-    let data = std::fs::read_to_string("tests/fixtures/example_sample.jsonl")
-        .expect("read fixture");
-    let mut lines = data.lines();
-    let line1 = lines.next().unwrap();
-    let line2 = lines.next().unwrap();
-
-    // Write both lines to temp file to represent the first execution
-    let mut file_after = NamedTempFile::new().unwrap();
-    writeln!(file_after, "{}", line1).unwrap();
-    writeln!(file_after, "{}", line2).unwrap();
-    file_after.flush().unwrap();
-    let parser_after = SessionParser::new(file_after.path());
+    // Load after fixture representing the first execution
+    let after_path = Path::new("tests/fixtures/transitions/after_example.jsonl");
+    let parser_after = SessionParser::new(after_path);
     let after_session = parser_after.parse().unwrap();
 
     // Build snapshots representing the first execution
@@ -35,10 +24,10 @@ fn test_transition_tool_extraction() {
     };
     let after_snap = EnvironmentSnapshot {
         files: HashMap::new(),
-        session_file: file_after.path().to_path_buf(),
+        session_file: after_path.to_path_buf(),
         session_id: Some(after_session.session_id.clone()),
         timestamp: Utc::now(),
-        session: Some(after_session),
+        session: Some(std::sync::Arc::new(after_session)),
     };
 
     // Dummy execution info

--- a/tests/transition_fixture_test.rs
+++ b/tests/transition_fixture_test.rs
@@ -1,0 +1,49 @@
+use claude_sdk::parser::SessionParser;
+use claude_sdk::execution::{ClaudePrompt, ClaudeExecution};
+use claude_sdk::execution::observer::EnvironmentSnapshot;
+use claude_sdk::execution::recorder::Transition;
+use uuid::Uuid;
+use std::collections::HashMap;
+use chrono::Utc;
+
+#[test]
+fn test_transition_followup_from_fixtures() {
+    let before_path = "tests/fixtures/transitions/before_example.jsonl";
+    let after_path = "tests/fixtures/transitions/after_example.jsonl";
+
+    let before_session = SessionParser::new(before_path).parse().expect("parse before");
+    let after_session = SessionParser::new(after_path).parse().expect("parse after");
+
+    let before_snap = EnvironmentSnapshot {
+        files: HashMap::new(),
+        session_file: before_path.into(),
+        session_id: Some(before_session.session_id.clone()),
+        timestamp: Utc::now(),
+        session: Some(std::sync::Arc::new(before_session)),
+    };
+    let after_snap = EnvironmentSnapshot {
+        files: HashMap::new(),
+        session_file: after_path.into(),
+        session_id: Some(after_session.session_id.clone()),
+        timestamp: Utc::now(),
+        session: Some(std::sync::Arc::new(after_session)),
+    };
+
+    let prompt = ClaudePrompt { text: "followup".to_string(), continue_session: true, resume_session_id: None };
+    let exec = ClaudeExecution { prompt: prompt.clone(), response: "ok".to_string(), session_id: "sess1".to_string(), cost: 0.0, duration_ms: 0, model: "test".to_string(), timestamp: Utc::now() };
+
+    let transition = Transition {
+        id: Uuid::new_v4(),
+        before: before_snap,
+        prompt,
+        execution: exec,
+        after: after_snap,
+        recorded_at: Utc::now(),
+        metadata: serde_json::Value::Null,
+    };
+
+    let new_msgs = transition.new_messages();
+    assert_eq!(new_msgs.len(), 1);
+    assert!(new_msgs[0].is_assistant_message());
+    assert!(transition.tool_executions().is_empty());
+}


### PR DESCRIPTION
## Summary
- add tool use/result fields to Message
- gather readable text from all content blocks
- expose full session snapshots in transitions
- return typed Messages from PyTransition.new_messages
- add small test fixture and Python test
- generate before/after transition fixtures with bash script

## Testing
- `cargo test`
- `uv build`
- `uv run -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841182b6edc832e8fe809dc57f2e04c