### PR TITLE
Rename package to Claude Code Analytics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,7 +148,7 @@ ls ../target/wheels/
 ## Configuration Files
 
 ### `Cargo.toml`
-- **Package name**: `claude-sdk` (matches Python package)
+- **Package name**: `claude-code-analytics` (matches Python package)
 - **Library name**: `claude_sdk` (matches Python import)
 - **Python feature**: Enable with `--features python`
 - **Excludes**: Top-level `python/` directory from Rust build
@@ -239,7 +239,7 @@ python -c "import sys; print(sys.executable)"
 pip list | grep claude
 
 # Reinstall if needed
-pip uninstall claude-sdk
+pip uninstall claude-code-analytics
 uv build
 ```
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,7 +66,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "claude-sdk"
+name = "claude-code-analytics"
 version = "0.1.0"
 dependencies = [
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "claude-sdk"
+name = "claude-code-analytics"
 version = "0.1.0"
 edition = "2021"
 exclude = ["python/.venv", "python/.pytest_cache", "target/", "dist/"]

--- a/README.md
+++ b/README.md
@@ -26,15 +26,15 @@ A high-performance Python library for parsing and analyzing Claude Code session 
 ### Install from PyPI (when published)
 
 ```bash
-pip install claude-sdk
+pip install claude-code-analytics
 ```
 
 ### Install from source
 
 ```bash
 # Clone the repository
-git clone https://github.com/darinkishore/claude-sdk.git
-cd claude-sdk
+git clone https://github.com/darinkishore/claude-code-analytics.git
+cd claude-code-analytics
 
 # Or using uv (recommended)
 uv pip install ./python
@@ -559,7 +559,7 @@ The Claude SDK is built with Rust for exceptional performance:
 
 **Solution**: Ensure you've installed the package:
 ```bash
-pip install claude-sdk
+pip install claude-code-analytics
 # or for development
 uv build
 ```
@@ -615,8 +615,8 @@ session = claude_sdk.load("session.jsonl")
 
 ```bash
 # Clone repository
-git clone https://github.com/yourusername/claude-sdk.git
-cd claude-sdk
+git clone https://github.com/yourusername/claude-code-analytics.git
+cd claude-code-analytics
 
 # Build Rust library
 cargo build --release
@@ -657,6 +657,6 @@ Built with:
 
 ## Support
 
-- **Issues**: [GitHub Issues](https://github.com/yourusername/claude-sdk/issues)
-- **Discussions**: [GitHub Discussions](https://github.com/yourusername/claude-sdk/discussions)
-- **Documentation**: [Full API Docs](https://yourusername.github.io/claude-sdk/)
+- **Issues**: [GitHub Issues](https://github.com/yourusername/claude-code-analytics/issues)
+- **Discussions**: [GitHub Discussions](https://github.com/yourusername/claude-code-analytics/discussions)
+- **Documentation**: [Full API Docs](https://yourusername.github.io/claude-code-analytics/)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "claude-sdk"
+name = "claude-code-analytics"
 version = "0.1.0"
 description = "Python SDK for Claude Code with Rust core"
 authors = [{ name = "Darin Kishore", email = "darinkishore@protonmail.com" }]

--- a/python/examples/README.md
+++ b/python/examples/README.md
@@ -79,7 +79,7 @@ Before running these examples, ensure you have:
 
 1. **Claude SDK installed**:
    ```bash
-   pip install claude-sdk
+   pip install claude-code-analytics
    # or for development
    cd ../.. && pip install ./python
    ```


### PR DESCRIPTION
## Summary
- rename package to `claude-code-analytics`
- update instructions and docs for new package name

## Testing
- `uv build`
- `uv run python - <<'EOF'
import claude_sdk
print('import success')
EOF`
- `cargo check`
- `cargo test` *(fails: ParseError missing 'type')*
- `uv run -m pytest python/tests`

------
https://chatgpt.com/codex/tasks/task_e_685f12ca1c8c832e89c20375027909ee