### PR TITLE
Add edge case tests for parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,7 @@ Thumbs.db
 *.jsonl
 !example*.jsonl  # Keep example files if any
 !tests/fixtures/example*.jsonl
+!python/tests/fixtures/*.jsonl
 
 # Old/backup directories
 backup_*/

--- a/README.md
+++ b/README.md
@@ -636,6 +636,10 @@ uv build
 uv run -m pytest tests/
 ```
 
+The Python test suite includes fixtures for malformed JSONL and a multi-megabyte
+session to ensure `ParseError` is raised correctly and large files load
+successfully.
+
 ### Contributing
 
 1. Fork the repository

--- a/python/tests/fixtures/malformed.jsonl
+++ b/python/tests/fixtures/malformed.jsonl
@@ -1,0 +1,2 @@
+{"type": "user", "message": {"role": "user"}}
+not a valid json line

--- a/python/tests/test_edge_cases.py
+++ b/python/tests/test_edge_cases.py
@@ -1,0 +1,17 @@
+import pytest
+from pathlib import Path
+import claude_sdk
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+MALFORMED = FIXTURES_DIR / "malformed.jsonl"
+LARGE_SESSION = Path(__file__).resolve().parents[2] / "tests" / "db68d083-0471-4213-8609-356b0bf38fec.jsonl"
+
+
+def test_malformed_jsonl_raises_parse_error():
+    with pytest.raises(claude_sdk.ParseError):
+        claude_sdk.load(MALFORMED)
+
+
+def test_large_session_loads():
+    session = claude_sdk.load(LARGE_SESSION)
+    assert len(session.messages) > 0


### PR DESCRIPTION
## Summary
- add malformed JSONL fixture
- add Python tests for malformed JSON and large sessions
- unignore JSONL fixtures and document new tests in README

## Testing
- `uv build`
- `uv run -m pytest python/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_685ef5013140832eb41a058f13d5aea9